### PR TITLE
Fix: Building using default downloaded externals.

### DIFF
--- a/scripts/build_externals
+++ b/scripts/build_externals
@@ -30,12 +30,12 @@ usage ()
 
 TARNAME="minotaur-externals-0.2"
 TARURL=http://www.mcs.anl.gov/~mahajan/minotaur/restricted/${TARNAME}.tar.gz
-ASL="asl-20161228"
-OSI="clp-1.16.9"
+ASL="asl-20150602"
+OSI="clp-1.16.6"
 CPPUNIT="cppunit-1.13.2"
 FILTERSQP="filter-102"
 BQPD="bqpd-3"
-IPOPT="ipopt-3.12.7"
+IPOPT="ipopt-3.12.3"
 LOG=
 ERR=
 CPUS=1

--- a/scripts/build_with_externals
+++ b/scripts/build_with_externals
@@ -49,10 +49,10 @@ USE_OSI=1
 USE_CURL=0
 USE_MAC=0
 
-ASL="asl-20161228"
+ASL="asl-20150602"
 CPPUNIT="cppunit-1.13.2"
-OSI="clp-1.16.9"
-IPOPT="ipopt-3.12.7"
+OSI="clp-1.16.6"
+IPOPT="ipopt-3.12.3"
 FILTERSQP="filter-102"
 BQPD="bqpd-3"
 


### PR DESCRIPTION
The directories for externals would now resolve for current default tar file specified. For custom externals, user can edit the directories in the script oneself.